### PR TITLE
Add Team Member List to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # ![NodeBB](public/images/sm-card.png)
 
+# Team: Bluey
+
+## Members
+- Lisa Huang (wenleh)
+- Diano Cano (dcano)
+- Luciana Requena (lrequena)
+- Michael Yan (tingxiay)
+- Sam Curry (scurry)
+
 ![Team Contribution Summary](https://raw.githubusercontent.com/CMU-313/NodeBB/gittogether-svg/activity.svg)
 
 [![Workflow](https://github.com/NodeBB/NodeBB/actions/workflows/test.yaml/badge.svg)](https://github.com/NodeBB/NodeBB/actions/workflows/test.yaml)


### PR DESCRIPTION
**Context:**
The README previously lacked information about the project team. Adding this section provides visibility into contributors, making it easier for collaborators and external reviewers to know who is on the team.

**Description of Changes:**
- Updated README.md to include a Team: Bluey section.
- Added a list of team members with their GitHub usernames.

**Testing / Verification:**
No code functionality impacted; verified that the README renders correctly with Markdown formatting.

**Additional Information:**
This is a documentation-only update, no functional or build changes introduced.