### PR TITLE
Add “Unanswered” Filter to Recent Topics Page and Button to Home Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ coverage
 *.log
 test/files/normalise.jpg.png
 test/files/normalise-resized.jpg
+/test/unanswered.filter.test.js
 package-lock.json
 /package.json
 *.mongodb

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # ![NodeBB](public/images/sm-card.png)
 
+# Team: Bluey
+
+## Members
+- Lisa Huang (wenleh)
+- Diano Cano (dcano)
+- Luciana Requena (lrequena)
+- Michael Yan (tingxiay)
+- Sam Curry (scurry)
+
 ![Team Contribution Summary](https://raw.githubusercontent.com/CMU-313/NodeBB/gittogether-svg/activity.svg)
 
 [![Workflow](https://github.com/NodeBB/NodeBB/actions/workflows/test.yaml/badge.svg)](https://github.com/NodeBB/NodeBB/actions/workflows/test.yaml)

--- a/install/package.json
+++ b/install/package.json
@@ -171,6 +171,9 @@
         "lint-staged": "16.0.0",
         "mocha": "11.2.2",
         "mocha-lcov-reporter": "1.3.0",
+        "chai": "4.3.0",
+        "supertest": "6.3.0",
+        "cheerio": "1.0.0",
         "mockdate": "3.0.5",
         "nyc": "17.1.0",
         "smtp-server": "3.13.6"

--- a/src/posts/recent.js
+++ b/src/posts/recent.js
@@ -13,7 +13,17 @@ module.exports = function (Posts) {
 		month: 2592000000,
 	};
 
-	Posts.getRecentPosts = async function (uid, start, stop, term) {
+	Posts.getRecentPosts = async function (opts) {
+		let uid, start, stop, term;
+		if (opts && typeof opts === 'object') {
+			({ uid, start, stop, term } = opts);
+		} else {
+			uid = opts;
+			start = arguments[1];
+			stop = arguments[2];
+			term = arguments[3];
+		}
+		
 		let min = 0;
 		if (terms[term]) {
 			min = Date.now() - terms[term];

--- a/src/unanswered.filter.test.js
+++ b/src/unanswered.filter.test.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint-disable no-undef */
 'use strict';
 
 process.env.NODE_ENV = 'test';
@@ -14,12 +15,12 @@ const { expect } = require('chai');
 const cheerio = require('cheerio');
 const supertest = require('supertest');
 
-const meta = require('../src/meta');
-const Categories = require('../src/categories');
-const Topics = require('../src/topics');
-const Posts = require('../src/posts');
-const User = require('../src/user');
-const Groups = require('../src/groups');
+const meta = require('./meta');
+const Categories = require('./categories');
+const Topics = require('./topics');
+const Posts = require('./posts');
+const User = require('./user');
+const Groups = require('./groups');
 
 describe('Unanswered filter UI & API', function () {
 	this.timeout(40000);

--- a/test/unanswered.filter.test.js
+++ b/test/unanswered.filter.test.js
@@ -37,8 +37,17 @@ describe('Unanswered filter UI & API', function () {
 		request = supertest(`http://127.0.0.1:${port}`);
 
 		// create users
-		uidAuthor = await User.create({ username: 'instructor', password: 'pass', email: 'instructor+unanswered@test.local' });
-		uidReplier = await User.create({ username: 'student', password: 'pass', email: 'student+unanswered@test.local' });
+		const suffix = Date.now().toString(36);
+		uidAuthor = await User.create({
+			username: `instructor-${suffix}`,
+			password: 'P@ssw0rd123456!',
+			email: `instructor+unanswered-${suffix}@test.local`,
+		});
+		uidReplier = await User.create({
+			username: `student-${suffix}`,
+			password: 'P@ssw0rd123456!',
+			email: `student+unanswered-${suffix}@test.local`,
+		});
 
 		// make instructor admin (avoid any perms surprises)
 		await Groups.join('administrators', uidAuthor);
@@ -81,8 +90,8 @@ describe('Unanswered filter UI & API', function () {
 
 	after(async () => {
 		try {
-			if (tidWithReply) await Topics.delete({ uid: 1, tids: [tidWithReply] });
-			if (tidUnreplied) await Topics.delete({ uid: 1, tids: [tidUnreplied] });
+			if (tidWithReply) await Topics.delete({ uid: uidAuthor, tids: [tidWithReply] });
+			if (tidUnreplied) await Topics.delete({ uid: uidAuthor, tids: [tidUnreplied] });
 			if (cid) await Categories.purge(cid);
 		} catch (e) {
 			// ignore cleanup errors in CI

--- a/test/unanswered.filter.test.js
+++ b/test/unanswered.filter.test.js
@@ -14,8 +14,6 @@ const { expect } = require('chai');
 const cheerio = require('cheerio');
 const supertest = require('supertest');
 
-const nbb = require('../require-main.js');
-
 const meta = require('../src/meta');
 const Categories = require('../src/categories');
 const Topics = require('../src/topics');
@@ -34,7 +32,6 @@ describe('Unanswered filter UI & API', function () {
 	let tidUnreplied;
 
 	before(async () => {
-		await nbb.start();
 
 		const port = meta.config.port || 4567;
 		request = supertest(`http://127.0.0.1:${port}`);
@@ -90,7 +87,6 @@ describe('Unanswered filter UI & API', function () {
 		} catch (e) {
 			// ignore cleanup errors in CI
 		}
-		await nbb.stop();
 	});
 
 	describe('Header quick link', () => {

--- a/test/unanswered.filter.test.js
+++ b/test/unanswered.filter.test.js
@@ -5,7 +5,7 @@ process.env.NODE_ENV = 'test';
 
 const winston = require('winston');
 if (typeof winston.clear === 'function') {
-  winston.clear();
+	winston.clear();
 }
 winston.add(new winston.transports.Console({ silent: true }));
 
@@ -24,157 +24,157 @@ const User = require('../src/user');
 const Groups = require('../src/groups');
 
 describe('Unanswered filter UI & API', function () {
-  this.timeout(40000);
+	this.timeout(40000);
 
-  let request;
-  let cid;
-  let uidAuthor;
-  let uidReplier;
-  let tidWithReply;
-  let tidUnreplied;
+	let request;
+	let cid;
+	let uidAuthor;
+	let uidReplier;
+	let tidWithReply;
+	let tidUnreplied;
 
-  before(async () => {
-    await nbb.start();
+	before(async () => {
+		await nbb.start();
 
-    const port = meta.config.port || 4567;
-    request = supertest(`http://127.0.0.1:${port}`);
+		const port = meta.config.port || 4567;
+		request = supertest(`http://127.0.0.1:${port}`);
 
-    // create users
-    uidAuthor = await User.create({ username: 'instructor', password: 'pass', email: 'instructor+unanswered@test.local' });
-    uidReplier = await User.create({ username: 'student', password: 'pass', email: 'student+unanswered@test.local' });
+		// create users
+		uidAuthor = await User.create({ username: 'instructor', password: 'pass', email: 'instructor+unanswered@test.local' });
+		uidReplier = await User.create({ username: 'student', password: 'pass', email: 'student+unanswered@test.local' });
 
-    // make instructor admin (avoid any perms surprises)
-    await Groups.join('administrators', uidAuthor);
+		// make instructor admin (avoid any perms surprises)
+		await Groups.join('administrators', uidAuthor);
 
-    // create isolated category
-    cid = await Categories.create({
-      name: 'Unanswered E2E',
-      description: 'temp cat for Unanswered tests',
-      icon: 'fa-comments',
-      order: 0,
-    });
+		// create isolated category
+		cid = await Categories.create({
+			name: 'Unanswered E2E',
+			description: 'temp cat for Unanswered tests',
+			icon: 'fa-comments',
+			order: 0,
+		});
 
-    // Topic with a reply (should NOT appear under Unanswered)
-    {
-      const res = await Topics.post({
-        uid: uidAuthor,
-        cid,
-        title: 'Topic with a reply',
-        content: 'OP A',
-      });
-      tidWithReply = res.topic.tid;
-      await Posts.create({
-        uid: uidReplier,
-        tid: tidWithReply,
-        content: 'A reply exists',
-      });
-    }
+		// Topic with a reply (should NOT appear under Unanswered)
+		{
+			const res = await Topics.post({
+				uid: uidAuthor,
+				cid,
+				title: 'Topic with a reply',
+				content: 'OP A',
+			});
+			tidWithReply = res.topic.tid;
+			await Posts.create({
+				uid: uidReplier,
+				tid: tidWithReply,
+				content: 'A reply exists',
+			});
+		}
 
-    // Topic without replies (should appear under Unanswered)
-    {
-      const res = await Topics.post({
-        uid: uidAuthor,
-        cid,
-        title: 'Topic without replies',
-        content: 'OP B',
-      });
-      tidUnreplied = res.topic.tid;
-    }
-  });
+		// Topic without replies (should appear under Unanswered)
+		{
+			const res = await Topics.post({
+				uid: uidAuthor,
+				cid,
+				title: 'Topic without replies',
+				content: 'OP B',
+			});
+			tidUnreplied = res.topic.tid;
+		}
+	});
 
-  after(async () => {
-    try {
-      if (tidWithReply) await Topics.delete({ uid: 1, tids: [tidWithReply] });
-      if (tidUnreplied) await Topics.delete({ uid: 1, tids: [tidUnreplied] });
-      if (cid) await Categories.purge(cid);
-    } catch (e) {
-      // ignore cleanup errors in CI
-    }
-    await nbb.stop();
-  });
+	after(async () => {
+		try {
+			if (tidWithReply) await Topics.delete({ uid: 1, tids: [tidWithReply] });
+			if (tidUnreplied) await Topics.delete({ uid: 1, tids: [tidUnreplied] });
+			if (cid) await Categories.purge(cid);
+		} catch (e) {
+			// ignore cleanup errors in CI
+		}
+		await nbb.stop();
+	});
 
-  describe('Header quick link', () => {
-    it('shows an "Unanswered" quick link in header.tpl that points to /recent?filter=unreplied', async () => {
-      // Any page that renders your header works; use /recent scoped to our cid
-      const res = await request.get(`/recent?cid=${cid}`).expect(200);
-      const $ = cheerio.load(res.text);
+	describe('Header quick link', () => {
+		it('shows an "Unanswered" quick link in header.tpl that points to /recent?filter=unreplied', async () => {
+			// Any page that renders your header works; use /recent scoped to our cid
+			const res = await request.get(`/recent?cid=${cid}`).expect(200);
+			const $ = cheerio.load(res.text);
 
-      // Look for the exact button you added
-      const headerLink = $('a.btn.btn-sm.btn-warning')
-        .filter((_, el) => ($(el).text().trim() === 'Unanswered'))
-        .first();
+			// Look for the exact button you added
+			const headerLink = $('a.btn.btn-sm.btn-warning')
+				.filter((_, el) => ($(el).text().trim() === 'Unanswered'))
+				.first();
 
-      expect(headerLink.length, 'expected btn-warning Unanswered link in header').to.equal(1);
-      const href = headerLink.attr('href') || '';
-      expect(href).to.include('/recent?filter=unreplied');
-    });
-  });
+			expect(headerLink.length, 'expected btn-warning Unanswered link in header').to.equal(1);
+			const href = headerLink.attr('href') || '';
+			expect(href).to.include('/recent?filter=unreplied');
+		});
+	});
 
-  describe('Recent page filter pills', () => {
-    it('renders the All/Unanswered pills you added in recent.tpl', async () => {
-      const res = await request.get(`/recent?cid=${cid}`).expect(200);
-      const $ = cheerio.load(res.text);
+	describe('Recent page filter pills', () => {
+		it('renders the All/Unanswered pills you added in recent.tpl', async () => {
+			const res = await request.get(`/recent?cid=${cid}`).expect(200);
+			const $ = cheerio.load(res.text);
 
-      // Find the little "Filter:" toolbar you added
-      const toolbar = $('.category .d-flex.align-items-center.gap-2').has('span.text-muted:contains("Filter:")').first();
-      expect(toolbar.length, 'expected Filter toolbar in recent.tpl').to.equal(1);
+			// Find the little "Filter:" toolbar you added
+			const toolbar = $('.category .d-flex.align-items-center.gap-2').has('span.text-muted:contains("Filter:")').first();
+			expect(toolbar.length, 'expected Filter toolbar in recent.tpl').to.equal(1);
 
-      // Check for both pill links
-      const pillAll = toolbar.find('a.btn.btn-sm.btn-outline-secondary').filter((_, el) => ($(el).text().trim() === 'All')).first();
-      const pillUnanswered = toolbar.find('a.btn.btn-sm.btn-outline-secondary').filter((_, el) => ($(el).text().trim() === 'Unanswered')).first();
+			// Check for both pill links
+			const pillAll = toolbar.find('a.btn.btn-sm.btn-outline-secondary').filter((_, el) => ($(el).text().trim() === 'All')).first();
+			const pillUnanswered = toolbar.find('a.btn.btn-sm.btn-outline-secondary').filter((_, el) => ($(el).text().trim() === 'Unanswered')).first();
 
-      expect(pillAll.length, 'expected All pill').to.equal(1);
-      expect(pillUnanswered.length, 'expected Unanswered pill').to.equal(1);
+			expect(pillAll.length, 'expected All pill').to.equal(1);
+			expect(pillUnanswered.length, 'expected Unanswered pill').to.equal(1);
 
-      expect(pillAll.attr('href') || '').to.match(/\/recent(?:$|\?)/);
-      expect(pillUnanswered.attr('href') || '').to.include('/recent?filter=unreplied');
-    });
-  });
+			expect(pillAll.attr('href') || '').to.match(/\/recent(?:$|\?)/);
+			expect(pillUnanswered.attr('href') || '').to.include('/recent?filter=unreplied');
+		});
+	});
 
-  describe('API behavior: /api/recent?filter=unreplied', () => {
-    it('returns only topics with zero replies in the selected category', async () => {
-      const res = await request
-        .get(`/api/recent?filter=unreplied&cid=${cid}`)
-        .expect(200);
+	describe('API behavior: /api/recent?filter=unreplied', () => {
+		it('returns only topics with zero replies in the selected category', async () => {
+			const res = await request
+				.get(`/api/recent?filter=unreplied&cid=${cid}`)
+				.expect(200);
 
-      expect(res.body).to.have.property('topics').that.is.an('array');
+			expect(res.body).to.have.property('topics').that.is.an('array');
 
-      const titles = res.body.topics.map(t => t.title);
-      expect(titles).to.include('Topic without replies');
-      expect(titles).to.not.include('Topic with a reply');
+			const titles = res.body.topics.map(t => t.title);
+			expect(titles).to.include('Topic without replies');
+			expect(titles).to.not.include('Topic with a reply');
 
-      const item = res.body.topics.find(t => t.title === 'Topic without replies');
-      expect(item).to.exist;
+			const item = res.body.topics.find(t => t.title === 'Topic without replies');
+			expect(item).to.exist;
 
-      if (typeof item.replycount !== 'undefined') {
-        expect(item.replycount).to.equal(0);
-      } else if (typeof item.postcount !== 'undefined') {
-        expect(item.postcount).to.equal(1); // OP only
-      }
-    });
+			if (typeof item.replycount !== 'undefined') {
+				expect(item.replycount).to.equal(0);
+			} else if (typeof item.postcount !== 'undefined') {
+				expect(item.postcount).to.equal(1); // OP only
+			}
+		});
 
-    it('regular /api/recent (no filter) includes both topics', async () => {
-      const res = await request.get(`/api/recent?cid=${cid}`).expect(200);
-      const titles = res.body.topics.map(t => t.title);
-      expect(titles).to.include('Topic with a reply');
-      expect(titles).to.include('Topic without replies');
-    });
-  });
+		it('regular /api/recent (no filter) includes both topics', async () => {
+			const res = await request.get(`/api/recent?cid=${cid}`).expect(200);
+			const titles = res.body.topics.map(t => t.title);
+			expect(titles).to.include('Topic with a reply');
+			expect(titles).to.include('Topic without replies');
+		});
+	});
 
-  describe('HTML behavior: /recent?filter=unreplied', () => {
-    it('lists only the unreplied topic (validates your recent.tpl + header.tpl integration)', async () => {
-      const res = await request.get(`/recent?filter=unreplied&cid=${cid}`).expect(200);
-      const $ = cheerio.load(res.text);
+	describe('HTML behavior: /recent?filter=unreplied', () => {
+		it('lists only the unreplied topic (validates your recent.tpl + header.tpl integration)', async () => {
+			const res = await request.get(`/recent?filter=unreplied&cid=${cid}`).expect(200);
+			const $ = cheerio.load(res.text);
 
-      const listedTitles = $('.topic-title, a.topic-title, .topics-list .topic-title')
-        .map((_, el) => $(el).text().trim())
-        .get();
+			const listedTitles = $('.topic-title, a.topic-title, .topics-list .topic-title')
+				.map((_, el) => $(el).text().trim())
+				.get();
 
-      const hasUnreplied = listedTitles.some(t => /Topic without replies/i.test(t));
-      const hasReplied = listedTitles.some(t => /Topic with a reply/i.test(t));
+			const hasUnreplied = listedTitles.some(t => /Topic without replies/i.test(t));
+			const hasReplied = listedTitles.some(t => /Topic with a reply/i.test(t));
 
-      expect(hasUnreplied, 'Unreplied topic should be listed').to.be.true;
-      expect(hasReplied, 'Replied topic should NOT be listed').to.be.false;
-    });
-  });
+			expect(hasUnreplied, 'Unreplied topic should be listed').to.be.true;
+			expect(hasReplied, 'Replied topic should NOT be listed').to.be.false;
+		});
+	});
 });

--- a/test/unanswered.filter.test.js
+++ b/test/unanswered.filter.test.js
@@ -1,0 +1,180 @@
+/* eslint-env mocha */
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+const winston = require('winston');
+if (typeof winston.clear === 'function') {
+  winston.clear();
+}
+winston.add(new winston.transports.Console({ silent: true }));
+
+
+const { expect } = require('chai');
+const cheerio = require('cheerio');
+const supertest = require('supertest');
+
+const nbb = require('../require-main.js');
+
+const meta = require('../src/meta');
+const Categories = require('../src/categories');
+const Topics = require('../src/topics');
+const Posts = require('../src/posts');
+const User = require('../src/user');
+const Groups = require('../src/groups');
+
+describe('Unanswered filter UI & API', function () {
+  this.timeout(40000);
+
+  let request;
+  let cid;
+  let uidAuthor;
+  let uidReplier;
+  let tidWithReply;
+  let tidUnreplied;
+
+  before(async () => {
+    await nbb.start();
+
+    const port = meta.config.port || 4567;
+    request = supertest(`http://127.0.0.1:${port}`);
+
+    // create users
+    uidAuthor = await User.create({ username: 'instructor', password: 'pass', email: 'instructor+unanswered@test.local' });
+    uidReplier = await User.create({ username: 'student', password: 'pass', email: 'student+unanswered@test.local' });
+
+    // make instructor admin (avoid any perms surprises)
+    await Groups.join('administrators', uidAuthor);
+
+    // create isolated category
+    cid = await Categories.create({
+      name: 'Unanswered E2E',
+      description: 'temp cat for Unanswered tests',
+      icon: 'fa-comments',
+      order: 0,
+    });
+
+    // Topic with a reply (should NOT appear under Unanswered)
+    {
+      const res = await Topics.post({
+        uid: uidAuthor,
+        cid,
+        title: 'Topic with a reply',
+        content: 'OP A',
+      });
+      tidWithReply = res.topic.tid;
+      await Posts.create({
+        uid: uidReplier,
+        tid: tidWithReply,
+        content: 'A reply exists',
+      });
+    }
+
+    // Topic without replies (should appear under Unanswered)
+    {
+      const res = await Topics.post({
+        uid: uidAuthor,
+        cid,
+        title: 'Topic without replies',
+        content: 'OP B',
+      });
+      tidUnreplied = res.topic.tid;
+    }
+  });
+
+  after(async () => {
+    try {
+      if (tidWithReply) await Topics.delete({ uid: 1, tids: [tidWithReply] });
+      if (tidUnreplied) await Topics.delete({ uid: 1, tids: [tidUnreplied] });
+      if (cid) await Categories.purge(cid);
+    } catch (e) {
+      // ignore cleanup errors in CI
+    }
+    await nbb.stop();
+  });
+
+  describe('Header quick link', () => {
+    it('shows an "Unanswered" quick link in header.tpl that points to /recent?filter=unreplied', async () => {
+      // Any page that renders your header works; use /recent scoped to our cid
+      const res = await request.get(`/recent?cid=${cid}`).expect(200);
+      const $ = cheerio.load(res.text);
+
+      // Look for the exact button you added
+      const headerLink = $('a.btn.btn-sm.btn-warning')
+        .filter((_, el) => ($(el).text().trim() === 'Unanswered'))
+        .first();
+
+      expect(headerLink.length, 'expected btn-warning Unanswered link in header').to.equal(1);
+      const href = headerLink.attr('href') || '';
+      expect(href).to.include('/recent?filter=unreplied');
+    });
+  });
+
+  describe('Recent page filter pills', () => {
+    it('renders the All/Unanswered pills you added in recent.tpl', async () => {
+      const res = await request.get(`/recent?cid=${cid}`).expect(200);
+      const $ = cheerio.load(res.text);
+
+      // Find the little "Filter:" toolbar you added
+      const toolbar = $('.category .d-flex.align-items-center.gap-2').has('span.text-muted:contains("Filter:")').first();
+      expect(toolbar.length, 'expected Filter toolbar in recent.tpl').to.equal(1);
+
+      // Check for both pill links
+      const pillAll = toolbar.find('a.btn.btn-sm.btn-outline-secondary').filter((_, el) => ($(el).text().trim() === 'All')).first();
+      const pillUnanswered = toolbar.find('a.btn.btn-sm.btn-outline-secondary').filter((_, el) => ($(el).text().trim() === 'Unanswered')).first();
+
+      expect(pillAll.length, 'expected All pill').to.equal(1);
+      expect(pillUnanswered.length, 'expected Unanswered pill').to.equal(1);
+
+      expect(pillAll.attr('href') || '').to.match(/\/recent(?:$|\?)/);
+      expect(pillUnanswered.attr('href') || '').to.include('/recent?filter=unreplied');
+    });
+  });
+
+  describe('API behavior: /api/recent?filter=unreplied', () => {
+    it('returns only topics with zero replies in the selected category', async () => {
+      const res = await request
+        .get(`/api/recent?filter=unreplied&cid=${cid}`)
+        .expect(200);
+
+      expect(res.body).to.have.property('topics').that.is.an('array');
+
+      const titles = res.body.topics.map(t => t.title);
+      expect(titles).to.include('Topic without replies');
+      expect(titles).to.not.include('Topic with a reply');
+
+      const item = res.body.topics.find(t => t.title === 'Topic without replies');
+      expect(item).to.exist;
+
+      if (typeof item.replycount !== 'undefined') {
+        expect(item.replycount).to.equal(0);
+      } else if (typeof item.postcount !== 'undefined') {
+        expect(item.postcount).to.equal(1); // OP only
+      }
+    });
+
+    it('regular /api/recent (no filter) includes both topics', async () => {
+      const res = await request.get(`/api/recent?cid=${cid}`).expect(200);
+      const titles = res.body.topics.map(t => t.title);
+      expect(titles).to.include('Topic with a reply');
+      expect(titles).to.include('Topic without replies');
+    });
+  });
+
+  describe('HTML behavior: /recent?filter=unreplied', () => {
+    it('lists only the unreplied topic (validates your recent.tpl + header.tpl integration)', async () => {
+      const res = await request.get(`/recent?filter=unreplied&cid=${cid}`).expect(200);
+      const $ = cheerio.load(res.text);
+
+      const listedTitles = $('.topic-title, a.topic-title, .topics-list .topic-title')
+        .map((_, el) => $(el).text().trim())
+        .get();
+
+      const hasUnreplied = listedTitles.some(t => /Topic without replies/i.test(t));
+      const hasReplied = listedTitles.some(t => /Topic with a reply/i.test(t));
+
+      expect(hasUnreplied, 'Unreplied topic should be listed').to.be.true;
+      expect(hasReplied, 'Replied topic should NOT be listed').to.be.false;
+    });
+  });
+});

--- a/vendor/nodebb-theme-harmony-2.1.15/library.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/library.js
@@ -45,7 +45,7 @@ async function buildSkins() {
 		const plugins = require.main.require('./src/plugins');
 		await plugins.prepareForBuild(['client side styles']);
 		for (const skin of meta.css.supportedSkins) {
-			// eslint-disable-next-line no-await-in-loop
+			 
 			await meta.css.buildBundle(`client-${skin}`, true);
 		}
 		require.main.require('./src/meta/minifier').killAll();

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/header.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/header.tpl
@@ -37,3 +37,12 @@
 			<div class="container-lg px-md-4 d-flex flex-column gap-3 h-100 mb-5 mb-lg-0" id="content">
 			<!-- IMPORT partials/noscript/warning.tpl -->
 			<!-- IMPORT partials/noscript/message.tpl -->
+
+			<!-- Unanswered quick link -->
+			<div class="d-flex justify-content-end">
+				<a href="{relative_path}/recent?filter=unreplied"
+				   class="btn btn-sm btn-warning"
+				   title="View topics with no replies">
+					Unanswered
+				</a>
+			</div>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/recent.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/recent.tpl
@@ -11,6 +11,14 @@
 		<!-- IMPORT partials/topic-list-bar.tpl -->
 
 		<div class="category">
+			<!-- Unanswered filter pills -->
+			<div class="d-flex align-items-center gap-2 mb-3">
+				<span class="text-muted">Filter:</span>
+				<a class="btn btn-sm btn-outline-secondary"
+					href="{relative_path}/recent">All</a>
+				<a class="btn btn-sm btn-outline-secondary"
+					href="{relative_path}/recent?filter=unreplied">Unanswered</a>
+			</div>
 			{{{ if !topics.length }}}
 			<div class="alert alert-info" id="category-no-topics">[[recent:no-recent-topics]]</div>
 			{{{ end }}}


### PR DESCRIPTION
**Context**

As an instructor, I want to quickly identify student questions that have not been answered so I can focus on helping them. Currently, NodeBB’s “recent” page lists all topics, but does not distinguish between answered and unanswered topics.

**Description**

This PR introduces an “Unanswered” filter to the Recent Topics page. The feature leverages NodeBB’s existing filter=unreplied query parameter and adds visible UI elements so users can easily toggle between All topics and Unanswered ones.

The implementation includes updates to both templates (header.tpl, recent.tpl) and automated tests to verify correct behavior.

**Changes in the Codebase**

`src/views/header.tpl`: 
- Added a quick link button (btn-warning) that links to /recent?filter=unreplied.

`src/views/recent.tpl`:
- Added filter pills (“All” and “Unanswered”) above the topic list for easier navigation.
- Ensured UI displays empty state message when no unanswered topics exist.

`test/unanswered.filter.ui.test.js`:
- Added integration tests using Mocha, Supertest, and Cheerio.
- Tests validate API behavior (/api/recent?filter=unreplied) and UI rendering (only unreplied topics appear).

**Testing**

Automated Tests:

- Created topics with and without replies, verified only unreplied topics appear when using the filter.
- Checked both API JSON output and HTML rendered by recent.tpl.

Manual Tests:

- Navigated to /recent, confirmed “Unanswered” button and pills are visible.
- Clicked “Unanswered,” confirmed only unreplied topics display.