### PR TITLE
Show responder role on posts + OpenAPI schema updates

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -372,6 +372,11 @@ PostDataObject:
         flagId:
           type: number
           description: The flag identifier, if this particular post has been flagged before
+        roleLabel:
+          type: string
+          description: Instructor/TA/Student label for the post author
+          enum: [Instructor, TA, Student]
+
     - type: object
       description: Optional properties that may or may not be present (except for `pid`, which is always present, and is only here as a hack to pass validation)
       properties:

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -101,7 +101,7 @@ topicsController.get = async function getTopic(req, res, next) {
 	}
 	const { start, stop } = calculateStartStop(currentPage, postIndex, settings);
 
-	// Load topic + posts that will be rendered
+	// Load topic + posts that will be rendered 
 	await topics.getTopicWithPosts(topicData, set, req.uid, start, stop, reverse);
 
 	/* NEW: attach role labels so templates can show (Instructor|TA|Student) */

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -111,11 +111,7 @@ topicsController.get = async function getTopic(req, res, next) {
 			const authorUid = parseInt((p.user && p.user.uid) || p.uid || 0, 10) || 0;
 			const role = await getRoleLabel(authorUid);
 
-			// Optional one-time debug; comment out when done
-			// winston.info('[roleLabel:page]', { pid: p.pid, authorUid, role });
-
 			p.roleLabel = role;
-			//if (p.user) p.user.roleLabel = role;
 			return p;
 		}));
 	}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/posts_list_item.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/posts_list_item.tpl
@@ -1,14 +1,23 @@
 <li component="post" class="posts-list-item  {{{ if ./deleted }}} deleted{{{ else }}}{{{ if ./topic.deleted }}} deleted{{{ end }}}{{{ end }}}{{{ if ./topic.scheduled }}} scheduled{{{ end }}}" data-pid="{./pid}" data-uid="{./uid}">
     <hr/>
     <a class="topic-title fw-semibold fs-5 mb-2 text-reset text-break d-block" href="{config.relative_path}/post/{encodeURIComponent(./pid)}">
-    {{{ if ./isMainPost }}}<i class="fa fa-book text-muted" title="[[topic:topic]]"></i> {{{ end }}}{./topic.title}
+        {{{ if ./isMainPost }}}<i class="fa fa-book text-muted" title="[[topic:topic]]"></i> {{{ end }}}{./topic.title}
     </a>
 
     <div class="post-body d-flex flex-column gap-1 mb-2">
         <div class="d-flex gap-2 post-info text-sm align-items-center">
             <div class="post-author d-flex align-items-center gap-1">
-                <a class="lh-1 text-decoration-none" href="{config.relative_path}/user/{./user.userslug}">{buildAvatar(./user, "16px", true, "not-responsive")}</a>
-                <a class="lh-1 fw-semibold" href="{config.relative_path}/user/{./user.userslug}">{../user.displayname}</a>
+                <a class="lh-1 text-decoration-none" href="{config.relative_path}/user/{./user.userslug}">
+                    {buildAvatar(./user, "16px", true, "not-responsive")}
+                </a>
+                <a class="lh-1 fw-semibold" href="{config.relative_path}/user/{./user.userslug}">
+                    {../user.displayname}
+                </a>
+                {{{ if ./roleLabel }}}
+                    <span class="ms-1 role-label">({./roleLabel})</span>
+                {{{ else }}}
+                    <span class="ms-1 role-label">(Student)</span>
+                {{{ end }}}
             </div>
             <span class="timeago text-muted lh-1" title="{./timestampISO}"></span>
         </div>
@@ -17,11 +26,14 @@
             {./content}
         </div>
     </div>
+
     <div class="mb-3 d-flex flex-wrap gap-1 w-100">
         {buildCategoryLabel(./category, "a", "border")}
         <span data-tid="{./topic.tid}" component="topic/tags" class="lh-1 tag-list d-flex flex-wrap gap-1 {{{ if !./topic.tags.length }}}hidden{{{ end }}}">
             {{{ each ./topic.tags }}}
-            <a href="{config.relative_path}/tags/{./valueEncoded}"><span class="badge border border-gray-300 fw-normal tag tag-class-{./class}" data-tag="{./value}">{./valueEscaped}</span></a>
+            <a href="{config.relative_path}/tags/{./valueEncoded}">
+                <span class="badge border border-gray-300 fw-normal tag tag-class-{./class}" data-tag="{./value}">{./valueEscaped}</span>
+            </a>
             {{{ end }}}
         </span>
     </div>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -44,6 +44,18 @@
 					</div>
 
 					<a class="fw-bold text-nowrap text-truncate" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+
+					<!-- ===== Role label: backend value if present, else default to (Student) ===== -->
+					{{{ if posts.roleLabel }}}
+						<span class="ms-1 role-label">({posts.roleLabel})</span>
+					{{{ else }}}
+						{{{ if posts.user.roleLabel }}}
+							<span class="ms-1 role-label">({posts.user.roleLabel})</span>
+						{{{ else }}}
+							<span class="ms-1 role-label">(Student)</span>
+						{{{ end }}}
+					{{{ end }}}
+					<!-- ====================================================================== -->
 				</div>
 
 				{{{ each posts.user.selectedGroups }}}
@@ -89,10 +101,10 @@
 			<div component="post/signature" data-uid="{posts.user.uid}" class="text-xs text-muted mt-2">{posts.user.signature}</div>
 			{{{ end }}}
 
-			<div class="d-flex flex-wrap-reverse gap-2 {{{ if (hideReplies || !posts.replies.count) }}}justify-content-end{{{ else }}}justify-content-between{{{ end }}}">
+			<div class="d-flex flex-wrap-reverse gap-2 {{{ if (hideReplies || !posts.replies.count) }}}justify-content-end{{{ else }}}justify-content-between{{{ end }}}}">
 				{{{ if !hideReplies }}}
-				<a component="post/reply-count" data-target-component="post/replies/container" href="#" class="d-flex gap-2 align-items-center btn btn-ghost ff-secondary border rounded-1 p-1 text-muted text-decoration-none text-xs {{{ if (!./replies || shouldHideReplyContainer(@value)) }}}hidden{{{ end }}}">
-					<span component="post/reply-count/avatars" class="d-flex gap-1 {{{ if posts.replies.hasMore }}}hasMore{{{ end }}}">
+				<a component="post/reply-count" data-target-component="post/replies/container" href="#" class="d-flex gap-2 align-items-center btn btn-ghost ff-secondary border rounded-1 p-1 text-muted text-decoration-none text-xs {{{ if (!./replies || shouldHideReplyContainer(@value)) }}}hidden{{{ end }}}}">
+					<span component="post/reply-count/avatars" class="d-flex gap-1 {{{ if posts.replies.hasMore }}}hasMore{{{ end }}}}">
 						{{{each posts.replies.users}}}
 						<span>{buildAvatar(posts.replies.users, "20px", true, "avatar-tooltip")}</span>
 						{{{end}}}


### PR DESCRIPTION
**Context**

In course forums it’s hard to tell whether a reply is from staff or a student at a glance. This PR surfaces the responder’s role next to their name on topics and post lists so instructors/TAs stand out and students get quick context.

**Description**

This pr adds the role of the responder behind their names for all users to see their role.

**Changes in the Codebase**
_Server_: compute a course-friendly role for each post author and attach it to the post payload as roleLabel
- Mapping:
  - Administrator → Instructor
  - Global Moderator/Moderator → TA
  - Everyone else → Student

_UI_: render the label next to the author’s display name
- partials/topic/post.tpl — shows ({posts.user.roleLabel || 'Student'})
- partials/posts_list_item.tpl — shows ({./roleLabel || 'Student'})

_OpenAPI schema_: allow optional roleLabel on post objects
- public/openapi/components/schemas/PostObject.yaml → add roleLabel: enum [Instructor, TA, Student]


**Automated Tests:**

test passed for all original

**Manual Tests:**
all thet

**follow up implementation**
add automated test cases

