### PR TITLE
WIP: Add nodebb-plugin-composer-topic-suggestions with Reactive UI

### DIFF
--- a/nodebb-plugin-composer-suggestions/library.js
+++ b/nodebb-plugin-composer-suggestions/library.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const plugin = {};
+
+plugin.init = async function (params) {
+    console.log('[composer-suggestions] init called');
+};
+
+module.exports = plugin;

--- a/nodebb-plugin-composer-suggestions/package.json
+++ b/nodebb-plugin-composer-suggestions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nodebb-plugin-composer-suggestions",
+  "version": "1.0.0",
+  "main": "library.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/nodebb-plugin-composer-suggestions/plugin.json
+++ b/nodebb-plugin-composer-suggestions/plugin.json
@@ -6,5 +6,6 @@
   "library": "library.js",
   "hooks": [
     { "hook": "static:app.load", "method": "init" }
-  ]
+  ],
+  "compatibility": "^3.0.0"
 }

--- a/nodebb-plugin-composer-suggestions/plugin.json
+++ b/nodebb-plugin-composer-suggestions/plugin.json
@@ -4,11 +4,11 @@
   "description": "Adds a section under the composer title for suggested topics.",
   "version": "0.0.1",
   "library": "library.js",
-  "scripts": [
-    "static/lib/main.js"
-  ],
   "hooks": [
     { "hook": "static:app.load", "method": "init" }
+  ],
+  "scripts": [
+    "static/lib/main.js"
   ],
   "compatibility": "^3.0.0"
 }

--- a/nodebb-plugin-composer-suggestions/plugin.json
+++ b/nodebb-plugin-composer-suggestions/plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "nodebb-plugin-composer-suggestions",
+  "name": "Composer Suggested Topics",
+  "description": "Adds a section under the composer title for suggested topics.",
+  "version": "0.0.1",
+  "library": "library.js",
+  "hooks": [
+    { "hook": "static:app.load", "method": "init" }
+  ]
+}

--- a/nodebb-plugin-composer-suggestions/plugin.json
+++ b/nodebb-plugin-composer-suggestions/plugin.json
@@ -4,6 +4,9 @@
   "description": "Adds a section under the composer title for suggested topics.",
   "version": "0.0.1",
   "library": "library.js",
+  "scripts": [
+    "static/lib/main.js"
+  ],
   "hooks": [
     { "hook": "static:app.load", "method": "init" }
   ],

--- a/nodebb-plugin-composer-suggestions/static/lib/main.js
+++ b/nodebb-plugin-composer-suggestions/static/lib/main.js
@@ -1,0 +1,11 @@
+'use strict';
+
+define('composer-suggestions/main', [], function () {
+    const Suggestions = {};
+
+    Suggestions.init = function () {
+        console.log('[composer-suggestions] main.js loaded');
+    };
+
+    return Suggestions;
+});

--- a/nodebb-plugin-composer-suggestions/static/lib/main.js
+++ b/nodebb-plugin-composer-suggestions/static/lib/main.js
@@ -1,6 +1,7 @@
 'use strict';
 
 define('composer-suggestions/main', [], function () {
+    console.log('[composer-suggestions] main.js entered');
     const Suggestions = {};
 
     Suggestions.init = function () {

--- a/nodebb-plugin-composer-suggestions/static/lib/main.js
+++ b/nodebb-plugin-composer-suggestions/static/lib/main.js
@@ -3,10 +3,24 @@
 define('composer-suggestions/main', [], function () {
     console.log('[composer-suggestions] main.js entered');
     const Suggestions = {};
+    // ChatGPT Assisted Code Below (.addPlaceholder function)
+    Suggestions.addPlaceholder = function (data) {
+        console.log('[composer-suggestions] adding placeholder...');
 
-    Suggestions.init = function () {
-        console.log('[composer-suggestions] main.js loaded');
+        const composerEl = $('.composer[data-uuid="' + data.post_uuid + '"]');
+        const titleEl = composerEl.find('input.title');
+
+        if (titleEl.length && !composerEl.find('.suggested-topics').length) {
+            titleEl.after(
+                '<div class="suggested-topics"><strong>Suggested Topics will appear here...</strong></div>'
+            );
+        }
     };
+
+    // Run when composer loads
+    $(window).on('action:composer.loaded', function (ev, data) {
+        Suggestions.addPlaceholder(data);
+    });
 
     return Suggestions;
 });

--- a/nodebb-plugin-composer-suggestions/static/lib/main.js
+++ b/nodebb-plugin-composer-suggestions/static/lib/main.js
@@ -10,14 +10,16 @@ define('composer-suggestions/main', [], function () {
         const composerEl = $('.composer[data-uuid="' + data.post_uuid + '"]');
         const titleEl = composerEl.find('input.title');
 
+        const titleContainer = composerEl.find('.title-container');
+
         if (titleEl.length && !composerEl.find('.suggested-topics').length) {
-            titleEl.after(
+            titleContainer.after(
                 '<div class="suggested-topics"><strong>Suggested Topics will appear here...</strong></div>'
             );
+             console.log('[composer-suggestions] ENTERED UI');
         }
     };
-
-    // Run when composer loads
+    
     $(window).on('action:composer.loaded', function (ev, data) {
         Suggestions.addPlaceholder(data);
     });


### PR DESCRIPTION
### **Context**
As a student, I want to see potentially related posts before I make a new one, so that I can check if someone has already posted something similar.

**Impact:** Reduces duplicate posts, enabling students to find answers more quickly while also minimizing repeated questions for instructors, leading to more efficient learning and discussion.

### **Description**

This PR introduces a new plugin that extends nodebb-plugin-composer-default by displaying potentially related or similarly titled posts beneath the composer title, allowing users to discover existing discussions before creating a new topic. Based on the composer’s title, the list of related posts will update dynamically.

**Steps for implementation:**
- [ ] Suggested Topics Plugin Skeleton Setup (Issue
- [ ] Hook nodebb-plugin-composer-suggestions into Composer Lifecycle
- [ ] Design Frontend "Related/Suggested Topics" UI
- [ ] Develop Backend Server-side Suggested Topics API


### **Changes in the codebase**

**Creation of `nodebb-plugin-composer-topic-suggestions` folder within the codebase and linked with `nodebb_modules`.**
**Files Created:**

`plugin.json`:
- Added plugin metadata

`library.js`:
- Added a basic init method that logs a message when the plugin is loaded.

`static/lib/main.js`:
- Added placeholder client-side script to confirm plugin assets are loaded.

### **Additional information**
- This PR is marked WIP since the suggested topics feature is not yet implemented.
- Next steps will include hooking into the composer lifecycle events.